### PR TITLE
Fix folders with spaces not working

### DIFF
--- a/FTP/FTPClient.cpp
+++ b/FTP/FTPClient.cpp
@@ -201,6 +201,7 @@ std::string CFTPClient::ParseURL(const std::string &strRemoteFile) const {
    std::string strURL = m_strServer + "/" + strRemoteFile;
 
    ReplaceString(strURL, "/", "//");
+   ReplaceString(strURL, " ", "%20"); //fixes folders with spaces not working
 
    std::string strUri = strURL;
 


### PR DESCRIPTION
During my testing of this library, I was trying to merge an FTP server that had a folder with a space in it. I figured out this was an issue with the URL parser, and I was able to fix it. Thanks for the great library, having a blast using it!